### PR TITLE
Initialize Next.js cake shop skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+node_modules
+.next
+.env
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Typescript cache
+.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# ceack_shop
+# Cake Shop Skeleton
+
+This repository contains a skeleton of a Next.js application for a cake store.
+The project follows a simple Feature-Sliced Design structure and uses TypeScript,
+Zustand for state management and Material UI for styling.
+
+## Structure
+
+- `src/pages` – application pages (index, catalog, cart, payment, cakes/[id])
+- `src/features` – feature modules (e.g. cart)
+- `src/entities` – domain entities (e.g. cake types)
+- `src/shared` – shared UI components and utilities
+
+To start developing locally, install dependencies and run `npm run dev`.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/messages/typescript

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  swcMinify: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "cake-shop",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@mui/material": "^5.15.8",
+    "@emotion/react": "^11.11.4",
+    "@emotion/styled": "^11.11.5",
+    "zustand": "^4.4.2"
+  },
+  "devDependencies": {
+    "typescript": "5.4.5"
+  }
+}

--- a/src/entities/cake/types.ts
+++ b/src/entities/cake/types.ts
@@ -1,0 +1,6 @@
+export interface Cake {
+  id: string;
+  name: string;
+  price: number;
+  image: string;
+}

--- a/src/features/cart/model/store.ts
+++ b/src/features/cart/model/store.ts
@@ -1,0 +1,16 @@
+import create from 'zustand';
+import { Cake } from '@/entities/cake/types';
+
+interface CartState {
+  items: Cake[];
+  add: (cake: Cake) => void;
+  remove: (id: string) => void;
+  clear: () => void;
+}
+
+export const useCartStore = create<CartState>((set) => ({
+  items: [],
+  add: (cake) => set((state) => ({ items: [...state.items, cake] })),
+  remove: (id) => set((state) => ({ items: state.items.filter((c) => c.id !== id) })),
+  clear: () => set({ items: [] }),
+}));

--- a/src/features/cart/ui/Cart.tsx
+++ b/src/features/cart/ui/Cart.tsx
@@ -1,0 +1,17 @@
+import { useCartStore } from '../model/store';
+import { Box, Typography } from '@mui/material';
+
+export const Cart = () => {
+  const items = useCartStore((state) => state.items);
+
+  return (
+    <Box>
+      <Typography variant="h4">Cart</Typography>
+      <ul>
+        {items.map((item) => (
+          <li key={item.id}>{item.name}</li>
+        ))}
+      </ul>
+    </Box>
+  );
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,0 +1,10 @@
+import type { AppProps } from 'next/app';
+import { ThemeProvider } from '@/shared/ui/ThemeProvider';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <ThemeProvider>
+      <Component {...pageProps} />
+    </ThemeProvider>
+  );
+}

--- a/src/pages/cakes/[id].tsx
+++ b/src/pages/cakes/[id].tsx
@@ -1,0 +1,12 @@
+import { useRouter } from 'next/router';
+import { Box, Typography } from '@mui/material';
+
+export default function CakePage() {
+  const { query } = useRouter();
+
+  return (
+    <Box>
+      <Typography variant="h4">Cake {query.id}</Typography>
+    </Box>
+  );
+}

--- a/src/pages/cart.tsx
+++ b/src/pages/cart.tsx
@@ -1,0 +1,5 @@
+import { Cart } from '@/features/cart/ui/Cart';
+
+export default function CartPage() {
+  return <Cart />;
+}

--- a/src/pages/catalog.tsx
+++ b/src/pages/catalog.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+import { Box, Typography, Button } from '@mui/material';
+
+export default function Catalog() {
+  const cakes = [
+    { id: '1', name: 'Chocolate Cake' },
+    { id: '2', name: 'Vanilla Cake' },
+  ];
+
+  return (
+    <Box>
+      <Typography variant="h4" gutterBottom>
+        Catalog
+      </Typography>
+      <ul>
+        {cakes.map((cake) => (
+          <li key={cake.id}>
+            <Button component={Link} href={`/cakes/${cake.id}`}>{cake.name}</Button>
+          </li>
+        ))}
+      </ul>
+    </Box>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+import { Typography, Box, Button } from '@mui/material';
+
+export default function Home() {
+  return (
+    <Box>
+      <Typography variant="h3" gutterBottom>
+        Cake Shop
+      </Typography>
+      <Button component={Link} href="/catalog" variant="contained">
+        Go to Catalog
+      </Button>
+    </Box>
+  );
+}

--- a/src/pages/payment.tsx
+++ b/src/pages/payment.tsx
@@ -1,0 +1,5 @@
+import { Typography } from '@mui/material';
+
+export default function Payment() {
+  return <Typography variant="h4">Payment Page</Typography>;
+}

--- a/src/shared/ui/ThemeProvider.tsx
+++ b/src/shared/ui/ThemeProvider.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react';
+import { ThemeProvider as MuiThemeProvider, createTheme } from '@mui/material/styles';
+
+const theme = createTheme();
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => (
+  <MuiThemeProvider theme={theme}>{children}</MuiThemeProvider>
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up Next.js skeleton project with TypeScript
- add Material UI theme provider and Zustand store
- scaffold pages for catalog, cart, payment, and individual cakes
- document project structure in README

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b64121dc8328a086b1413718936e