### PR TITLE
Style home page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,15 +1,33 @@
 import Link from 'next/link';
-import { Typography, Box, Button } from '@mui/material';
+import { Typography, Box, Button, Container } from '@mui/material';
 
 export default function Home() {
   return (
-    <Box>
-      <Typography variant="h3" gutterBottom>
-        Cake Shop
-      </Typography>
-      <Button component={Link} href="/catalog" variant="contained">
-        Go to Catalog
-      </Button>
+    <Box
+      sx={{
+        backgroundColor: 'primary.main',
+        color: 'primary.contrastText',
+        py: { xs: 8, md: 16 },
+        textAlign: 'center',
+      }}
+    >
+      <Container maxWidth="md">
+        <Typography variant="h2" component="h1" gutterBottom>
+          Cake Shop
+        </Typography>
+        <Typography variant="h6" paragraph>
+          Свежие десерты каждый день
+        </Typography>
+        <Button
+          component={Link}
+          href="/catalog"
+          variant="contained"
+          color="secondary"
+          size="large"
+        >
+          Перейти в каталог
+        </Button>
+      </Container>
     </Box>
   );
 }

--- a/src/shared/ui/ThemeProvider.tsx
+++ b/src/shared/ui/ThemeProvider.tsx
@@ -1,7 +1,19 @@
 import { ReactNode } from 'react';
-import { ThemeProvider as MuiThemeProvider, createTheme } from '@mui/material/styles';
+import {
+  ThemeProvider as MuiThemeProvider,
+  createTheme,
+} from '@mui/material/styles';
 
-const theme = createTheme();
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#7cb342',
+    },
+    secondary: {
+      main: '#fdd835',
+    },
+  },
+});
 
 export const ThemeProvider = ({ children }: { children: ReactNode }) => (
   <MuiThemeProvider theme={theme}>{children}</MuiThemeProvider>


### PR DESCRIPTION
## Summary
- add green color palette via ThemeProvider
- redesign home page with a green hero section and button

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b898f4048328900728d7dbf3c90e